### PR TITLE
v0.7 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - `batch_size` is auto adjusted based on number of workers and gradient_accum (huh! finally)
 - `batch_size` normalizer in distributed training setting (fix! faster convergence now)
 - support for `byte` encoding added
+- Validation metrics; previously BLEU was teacher-forced similar to validation loss, now BLEU is from autoregressive output (resembling test time)
+- 
 - 
 
 # v0.6.0 : 20210921

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `batch_size` normalizer in distributed training setting (fix! faster convergence now)
 - support for `byte` encoding added
 - Validation metrics; previously BLEU was teacher-forced similar to validation loss, now BLEU is from autoregressive output (resembling test time)
-- 
+  - Use bfloat16 for mixed precision training, requires torch 1.10+
 - 
 
 # v0.6.0 : 20210921

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
-# v0.7 - WIP
-- 
-
+# v0.7 - 20220315
+- Big improvements:
+  - Autocast / mixed precision: `bfloat16` instead of `float16`. Now we can train larger models on larger batches using 16bit float ops without loss becoming infinity!  
+    - WARNING: we need pytorch 1.10 or newer. Please upgrade!
+  - validation BLEU scores are computed without teacher forcing i.e., similar to inference. BLEU is more realistic estimate of test time bleu
+    - WARNING: validations can be slower. Dont use too big validation set
+  - schedule:
+    - `inverse_sqrt` support scaler multiplier term, similar to `noam`
+    - `inverse_root` schedule added, generalization of `inverse_sqrt`
+- fixes
+  - `rtg.prep` CLI arguments works now
+  - optimizer state loading now works while resuming training
+  - parent model will be recreated if missing even after _PREPARED flag exists
+  
 
 # v0.6.1 : 20220128
 - `rtg.fork` accepts multiple to_dir; thus supports cloning multiple times at once

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# v0.6.1 : WIP
+# v0.7 - WIP
+- 
+
+
+# v0.6.1 : 20220128
 - `rtg.fork` accepts multiple to_dir; thus supports cloning multiple times at once
 - Bug fix: early stopping on distributed parallel training
 - `rtg.tool.augment` to support data augmentations

--- a/rtg/__init__.py
+++ b/rtg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.6.1'
+__version__ = '0.7'
 
 
 import os

--- a/rtg/distrib/__init__.py
+++ b/rtg/distrib/__init__.py
@@ -43,6 +43,8 @@ class DistribTorch:
     _model: nn.Module = None
     _clip_grad_max_norm = None
 
+    _n_skips = 0
+
     def setup(self):
         log.info("DistribTorch setup()")
         if self.world_size > 1:
@@ -124,17 +126,25 @@ class DistribTorch:
         # else we dont need it
 
     def backward(self, loss, retain_graph=False):
+        
         if torch.isnan(loss):
+            if self._n_skips < self.grad_accum - 1:
+                log.warning(f"Loss is nan; skipping. n_skips={self._n_skips} grad_accum={self.grad_accum}")
+                self._n_skips += 1
+                return
+            # else crash
             raise Exception('''Loss is nan; enable debug mode to know more (export NMT_DEBUG=true);
     Or, here are some tips:
     1. reduce the learning rate
     2. reduce batch size
     3. set trainer.init_args.clip_grad_norm to a small number e.g. 5.0''')
+    
         if self.fp16:
             loss = self._scaler.scale(loss)
         if loss < 0:
-            raise Exception('Loss is negative; looks like a numerical error (underflow or overflow?')
+            raise Exception('Loss is negative; looks like a numerical error (underflow or overflow?)')
         loss.backward(retain_graph=retain_graph)
+        self._n_skips = 0 # reset
 
     def average_gradients(self, model):
         size = float(self.world_size)
@@ -153,7 +163,7 @@ class DistribTorch:
                 # Unscales the gradients of optimizer's assigned params in-place
                 self._scaler.unscale_(optimizer)
             # Since the gradients of optimizer's assigned params are unscaled, clips as usual:
-            torch.nn.utils.clip_grad_norm_(self._model.parameters(), self._clip_grad_max_norm)
+            torch.nn.utils.clip_grad_norm_(self._model.parameters(), self._clip_grad_max_norm) #  error_if_nonfinite=False
 
         if self.fp16:
             self._scaler.step(optimizer)

--- a/rtg/distrib/__init__.py
+++ b/rtg/distrib/__init__.py
@@ -148,9 +148,16 @@ class DistribTorch:
 
     def average_gradients(self, model):
         size = float(self.world_size)
+        # dist.all_reduce_coalesced(list(model.parameters()), op=dist.ReduceOp.SUM)  # unavailable
+        futures = []
         for param in model.parameters():
-            dist.all_reduce(param.grad.data, op=dist.ReduceOp.SUM)
+            work = dist.all_reduce(param.grad.data, op=dist.ReduceOp.SUM, async_op=True)
+            futures.append((work, param))
             # TODO: ring reduce https://pytorch.org/tutorials/intermediate/dist_tuto.html#our-own-ring-allreduce
+            #param.grad.data /= size
+        
+        for work, param in futures:
+            work.wait()  # if not complete
             param.grad.data /= size
 
     def step(self, optimizer: Optimizer):

--- a/rtg/exp.py
+++ b/rtg/exp.py
@@ -85,6 +85,7 @@ class BaseExperiment:
             if self._shared_field_file.exists() else None
 
         self.last_state_file = self.model_dir / 'last_state.pt'
+        self.parent_model_state = self.data_dir / 'parent_model_state.pt'
 
     @property
     def problem_type(self):
@@ -259,12 +260,12 @@ class BaseExperiment:
         return None
 
     def pre_process(self, args=None, force=False):
+        if 'parent' in self.config and not self.parent_model_state.exists():
+            self.inherit_parent()
         if self.has_prepared() and not force:
             log.warning("Already prepared")
             return
         args = args if args else self.config['prep']
-        if 'parent' in self.config:
-            self.inherit_parent()
 
         if 'same_data' in args:
             data = Path(args['same_data']) / 'data'
@@ -413,7 +414,7 @@ class TranslationExperiment(BaseExperiment):
             self.mono_valid_src = self.data_dir / 'mono.valid.src.gz'
             self.mono_valid_tgt = self.data_dir / 'mono.valid.tgt.gz'
 
-        self.parent_model_state = self.data_dir / 'parent_model_state.pt'
+
 
     @property
     def problem_type(self):
@@ -815,7 +816,8 @@ class TranslationExperiment(BaseExperiment):
 
     def pre_process(self, args=None, force=False):
         args = args or self.config['prep']
-        super(TranslationExperiment, self).pre_process(args, )
+        super(TranslationExperiment, self).pre_process(args)
+
         if self.has_prepared() and not force:
             log.warning("Already prepared")
             return

--- a/rtg/module/decoder.py
+++ b/rtg/module/decoder.py
@@ -396,17 +396,17 @@ class Decoder:
         else:  # all others go from source as input to target as output
             return self.exp.tgt_vocab
 
-    def decode_sentence(self, line: str, max_len=20, prepared=False, **args) -> List[StrHypothesis]:
+    def decode_sentence(self, line: str, max_len=20, prepared=False, add_bos=False, **args) -> List[StrHypothesis]:
 
         line = line.strip()
         if prepared:
             in_seq = [int(t) for t in line.split()]
-            if in_seq[0] != self.bos_val:
+            if add_bos and in_seq[0] != self.bos_val:
                 in_seq.insert(0, self.bos_val)
             if in_seq[-1] != self.eos_val:
                 in_seq.append(self.eos_val)
         else:
-            in_seq = self.inp_vocab.encode_as_ids(line, add_eos=True, add_bos=False)
+            in_seq = self.inp_vocab.encode_as_ids(line, add_eos=True, add_bos=add_bos)
         in_seqs = tensor(in_seq, dtype=torch.long).view(1, -1)
         in_lens = tensor([len(in_seq)], dtype=torch.long)
         if self.debug:

--- a/rtg/module/schedule.py
+++ b/rtg/module/schedule.py
@@ -35,6 +35,28 @@ class Noam(LRSchedule):
                                                             step * self.warmup ** -1.5)
 
 
+@register(SCHEDULE, 'inverse_root')
+@dataclass
+class InverseRoot(LRSchedule):
+
+    warmup: int
+    peak_lr: float
+    init_lr: 0.0
+    constant: int = 1
+    decay_power: float = 0.5
+
+    def __post_init__(self):
+        assert self.init_lr < self.peak_lr, f'init_lr must be lower than peak_lr'
+        assert self.constant > 0
+        assert 0 < self.decay_power < 1, f'set 0.5 for sqrt, 0.3 for cube root etc. given {self.decay_power}'
+
+    def rate(self, step) -> float:
+        return self.constant * min(
+            self.init_lr + step * (self.peak_lr - self.init_lr) / self.warmup,
+            self.peak_lr * self.warmup ** self.decay_power * step ** -self.decay_power
+        )
+
+
 @register(SCHEDULE, 'inverse_sqrt')
 @dataclass
 class InverseSqrt(LRSchedule):

--- a/rtg/module/schedule.py
+++ b/rtg/module/schedule.py
@@ -38,7 +38,8 @@ class Noam(LRSchedule):
 @register(SCHEDULE, 'inverse_root')
 @dataclass
 class InverseRoot(LRSchedule):
-
+    # for a visualization, see https://www.desmos.com/calculator/qadmmahb2t
+    
     warmup: int
     peak_lr: float
     init_lr: 0.0

--- a/rtg/module/schedule.py
+++ b/rtg/module/schedule.py
@@ -41,15 +41,18 @@ class InverseSqrt(LRSchedule):
     warmup: int
     peak_lr: float
     init_lr: 0.0
+    constant: int = 1
 
     def __post_init__(self):
         assert self.init_lr < self.peak_lr, f'init_lr must be lower than peak_lr'
+        assert self.constant > 0
 
     def rate(self, step) -> float:
         if step <= self.warmup:
-            return self.init_lr + step * (self.peak_lr - self.init_lr) / self.warmup
+            lr = self.init_lr + step * (self.peak_lr - self.init_lr) / self.warmup
         else:
-            return self.peak_lr * self.warmup ** 0.5 * step ** -0.5
+            lr = self.peak_lr * self.warmup ** 0.5 * step ** -0.5
+        return self.constant * lr
 
 
 @dataclass

--- a/rtg/module/tfmnmt.py
+++ b/rtg/module/tfmnmt.py
@@ -399,8 +399,8 @@ def attention(query, key, value, mask=None, dropout=None, query_key_emb: 'Relati
         # for devising this concise code. I needed a lot of time to understand how this code works!
         #
         #scores = scores.masked_fill(mask == 0, -1e9)
-        #low_val = -2 ** 14 if dtorch.fp16 else -1e9  # -2**15 causes nan
-        low_val = -2 ** 13 if dtorch.fp16 else -1e9  # -2**15 causes nan
+        low_val = -2 ** 14 if dtorch.fp16 else -1e9  # -2**15 causes nan
+        #low_val = -2 ** 13 if dtorch.fp16 else -1e9  # -2**15 causes nan
         scores = scores.masked_fill(mask == 0, low_val)
     p_attn = F.softmax(scores, dim=-1)  # [BatchSize x Heads x Time=SeqLen x SeqLen ]
     if dropout is not None:
@@ -987,7 +987,7 @@ class SimpleLossFunction:
         else:
             total_toks = mask_out.shape[0] - mask_out.sum()
             # scale batch size back
-            total_toks *= dtorch.batch_size_scaler
+            # total_toks *= dtorch.batch_size_scaler
         assert total_toks > 0
 
         if not get_out and self.subcls_gen:
@@ -1045,7 +1045,7 @@ class ChunkedLossCompute(SimpleLossFunction):
         else:
             total_toks = mask_out.shape[0] * mask_out.shape[1] - mask_out.sum()
             # scale batch  size back
-            total_toks *= dtorch.batch_size_scaler
+            # total_toks *= dtorch.batch_size_scaler
         assert total_toks > 0 
 
         sub_vocab = None

--- a/rtg/module/tfmnmt.py
+++ b/rtg/module/tfmnmt.py
@@ -377,8 +377,10 @@ def attention(query, key, value, mask=None, dropout=None, query_key_emb: 'Relati
     # Beware: this is a batch multiplier!
     # See https://pytorch.org/docs/stable/torch.html?highlight=matmul#torch.matmul
     scores = torch.matmul(query, key.transpose(-2, -1))
+    # incase of mixed precision, force full float
+    
+    #scores = scores.float()
     if query_key_emb is not None:
-        # the above impementation was memory inefficient, so rewrote this
         rel_scores = query_key_emb(query=query, key=key)
         scores = scores + rel_scores
     scores = scores / math.sqrt(d_k)
@@ -396,15 +398,18 @@ def attention(query, key, value, mask=None, dropout=None, query_key_emb: 'Relati
         # Now, if you got this, take a moment to thank http://nlp.seas.harvard.edu/rush.html
         # for devising this concise code. I needed a lot of time to understand how this code works!
         #
-        # scores = scores.masked_fill(mask == 0, -1e9)
-        low_val = -2 ** 14 if dtorch.fp16 else -1e9  # -2**15 causes nan
-        #low_val = -1e9
+        #scores = scores.masked_fill(mask == 0, -1e9)
+        #low_val = -2 ** 14 if dtorch.fp16 else -1e9  # -2**15 causes nan
+        low_val = -2 ** 13 if dtorch.fp16 else -1e9  # -2**15 causes nan
         scores = scores.masked_fill(mask == 0, low_val)
     p_attn = F.softmax(scores, dim=-1)  # [BatchSize x Heads x Time=SeqLen x SeqLen ]
     if dropout is not None:
         p_attn = dropout(p_attn)
+        
     # Beware: this is a batch multiplier!
+    
     ctx_vals = torch.matmul(p_attn, value)
+    #ctx_vals = ctx_vals.to(value.dtype)  # p_attn maybe float, value maybe half
     return ctx_vals, p_attn
 
 class RelativePositionEmbedding(nn.Module):
@@ -782,7 +787,7 @@ class TransformerTrainer(SteppedTrainer):
                 y_mask = batch.make_autoreg_mask(y_seqs_in)
 
                 with autocast(enabled=dtorch.fp16):
-                    loss = self._train_step(take_step, x_mask, x_seqs, y_mask, y_seqs_in, y_seqs_out)
+                    loss = self._train_step(take_step, x_mask, x_seqs, y_mask, y_seqs_in, y_seqs_out)  #norm=max_toks
 
                 if stopper and take_step:
                     stopper.step()
@@ -847,13 +852,13 @@ class TransformerTrainer(SteppedTrainer):
         dtorch.barrier()
         return early_stopped_flag.exists()
 
-    def _train_step(self, take_step: bool, x_mask, x_seqs, y_mask, y_seqs_in, y_seqs_out):
+    def _train_step(self, take_step: bool, x_mask, x_seqs, y_mask, y_seqs_in, y_seqs_out, norm=None):
         # [Batch x Time x D]
         out = self.model(x_seqs, y_seqs_in, x_mask, y_mask)
         # skip the last time step (the one with EOS as input)
         out = out[:, :-1, :]
         # assumption:  y_seqs has EOS, and not BOS
-        loss = self.loss_func(out, y_seqs_out, train_mode=True, take_step=take_step)
+        loss = self.loss_func(out, y_seqs_out, train_mode=True, take_step=take_step, norm=norm)
         return loss
 
     def _log_resources(self, batch):
@@ -973,12 +978,16 @@ class SimpleLossFunction:
             sub_vocab = torch.cat([sub_vocab, neg_classes])
         return sub_vocab, tgt_rev_idx
 
-    def __call__(self, x_feats, y_seqs, train_mode=True, take_step=True, get_out=False):
+    def __call__(self, x_feats, y_seqs, train_mode=True, take_step=True, get_out=False, norm=None):
         # B x T x D --> B x T x V
         mask_out = (y_seqs == self.vocab.pad_idx).view(-1, 1)
-        total_toks = mask_out.shape[0] - mask_out.sum()
-        # scale batch size back
-        total_toks *= dtorch.batch_size_scaler
+        if norm:
+            total_toks = norm
+        else:
+            total_toks = mask_out.shape[0] - mask_out.sum()
+            # scale batch size back
+            total_toks *= dtorch.batch_size_scaler
+        assert total_toks > 0
 
         if not get_out and self.subcls_gen:
             sub_vocab, y_seqs = self.get_sub_vocab(y_seqs)
@@ -1011,7 +1020,7 @@ class ChunkedLossCompute(SimpleLossFunction):
         if self.criterion.reduction == 'macro':
             raise Exception('ChunkedLoss doesnt support reduction=macro; set chunk_size=0 to disable ChunkedLoss')
 
-    def __call__(self, y_feats, y_seqs, train_mode=True, chunk_size=None, take_step=True, get_out=False):
+    def __call__(self, y_feats, y_seqs, train_mode=True, chunk_size=None, take_step=True, get_out=False, norm=None):
         """
         :param y_feats:
         :param y_seqs:
@@ -1030,9 +1039,13 @@ class ChunkedLossCompute(SimpleLossFunction):
         out_chunks = []
         count = 0
         mask_out = (y_seqs == self.vocab.pad_idx)
-        total_toks = mask_out.shape[0] * mask_out.shape[1] - mask_out.sum()
-        # scale batch  size back
-        total_toks *= dtorch.batch_size_scaler
+        if norm:
+            total_toks = norm
+        else:
+            total_toks = mask_out.shape[0] * mask_out.shape[1] - mask_out.sum()
+            # scale batch  size back
+            total_toks *= dtorch.batch_size_scaler
+        assert total_toks > 0 
 
         sub_vocab = None
         if not get_out and self.subcls_gen:
@@ -1060,6 +1073,7 @@ class ChunkedLossCompute(SimpleLossFunction):
             total += loss.detach().item()
             if train_mode:
                 dtorch.backward(loss)
+        assert count > 0
         total /= count
         if train_mode:
             if _y_feats.grad is None:

--- a/rtg/module/trainer.py
+++ b/rtg/module/trainer.py
@@ -173,10 +173,6 @@ class SteppedTrainer:
         self.n_gpus = torch.cuda.device_count()
         self.device_ids = list(range(self.n_gpus))
         self.core_model = self.model.to(device)
-        if last_state_file:
-            self.load_state(chkpt_path=last_state_file)
-        else:
-            log.info("No earlier check point found. Looks like this is a fresh start")
 
         trainable_params = self.exp.config['optimizer'].get('trainable', {})
         if trainable_params:
@@ -188,6 +184,11 @@ class SteppedTrainer:
             trainable_params = self.model.parameters()
 
         self.core_opt = exp.get_optimizer(params=trainable_params)
+        if last_state_file:
+            self.load_state(chkpt_path=last_state_file)
+        else:
+            log.info("No earlier check point found. Looks like this is a fresh start")
+
         self.model = dtorch.maybe_distributed(self.core_model)
         self.opt = ScheduledOptimizer(start_step=self.start_step, schedule=exp.get_schedule(), optimizer=self.core_opt)
 

--- a/rtg/module/trainer.py
+++ b/rtg/module/trainer.py
@@ -5,6 +5,7 @@
 import torch
 import rtg
 from rtg import log, yaml, TranslationExperiment as Experiment, device, BatchIterable
+from rtg.registry import ProblemType
 from rtg.module import NMTModel
 from rtg.utils import IO
 from rtg.module.schedule import ScheduledOptimizer
@@ -207,6 +208,7 @@ class SteppedTrainer:
                     for samp_num, sample in enumerate(self.samples):
                         self.tbd.add_text(f"sample/{samp_num}", " || ".join(sample), 0)
 
+        if exp.problem_type == ProblemType.TRANSLATION:
             from rtg.module.decoder import Decoder
             self.decoder = Decoder.new(self.exp, self.core_model)
 

--- a/rtg/pipeline.py
+++ b/rtg/pipeline.py
@@ -332,7 +332,7 @@ class Pipeline:
             self.exp.reload()  # with updated config and vocabs from global_main
         # train on all
         if debug:
-            log.warning("<<<Anomoly detection enabled; this is very slow; use this only for debugging/hunting bugs>>>")
+            log.warning("<<<Anomaly detection enabled; this is very slow; use this only for debugging/hunting bugs>>>")
             with torch.autograd.detect_anomaly():
                 self.exp.train()
         else:

--- a/rtg/prep.py
+++ b/rtg/prep.py
@@ -9,7 +9,7 @@ from rtg.exp import load_conf
 
 def parse_args():
     parser = argparse.ArgumentParser(prog="rtg.prep", description="prepare NMT experiment")
-    parser.add_argument("work_dir", help="Working directory", type=Path)
+    parser.add_argument("exp_dir", help="experiment directory", type=Path)
     parser.add_argument("conf_file", type=Path, nargs='?',
                         help="Config File. By default <work_dir>/conf.yml is used")
     return parser.parse_args()
@@ -17,7 +17,7 @@ def parse_args():
 
 def main():
     args = parse_args()
-    conf_file: Path = args.conf_file if args.conf_file else args.work_dir / 'conf.yml'
+    conf_file: Path = args.conf_file if args.conf_file else args.exp_dir / 'conf.yml'
     assert conf_file.exists()
     ExpFactory = TranslationExperiment
     is_big = load_conf(conf_file).get('spark', {})
@@ -32,7 +32,7 @@ def main():
         from rtg.big.exp import BigTranslationExperiment
         ExpFactory = BigTranslationExperiment
 
-    exp = ExpFactory(args.exp, config=conf_file, read_only=False)
+    exp = ExpFactory(args.exp_dir, config=conf_file, read_only=False)
     return exp.pre_process()
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
         'tensorboard >= 2.6.0',
         'tqdm >= 4.45.0',
         'nlcodec >= 0.5',
-        'torch >= 1.8.0',
+        'torch >= 1.10',  # AMP with bfloat16 came in 1.10
         'sacremoses >= 0.0.45',
         'portalocker >= 2.0.0',
         'torchtext >= 0.10.0',


### PR DESCRIPTION
- Big improvements:
  - Autocast / mixed precision: `bfloat16` instead of `float16`. Now we can train larger models on larger batches using 16bit float ops without loss becoming infinity!  
    - WARNING: we need pytorch 1.10 or newer. Please upgrade!
  - validation BLEU scores are computed without teacher forcing i.e., similar to inference. BLEU is more realistic estimate of test time bleu
    - WARNING: validations can be slower. Dont use too big validation set
  - schedule:
    - `inverse_sqrt` support scaler multiplier term, similar to `noam`
    - `inverse_root` schedule added, generalization of `inverse_sqrt`
- fixes
  - `rtg.prep` CLI arguments works now
  - optimizer state loading now works while resuming training (closes #18 )
  - parent model will be recreated if missing even after _PREPARED flag exists
  